### PR TITLE
Add CI and pre-hook script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Continous Integration
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  CARGO_TERM_COLORS: always
+
+jobs:
+  clippy_fmt_docs_check:
+    name: Check clippy lints, formatting and docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy,rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Check without any feature
+        run: cargo clippy --no-default-features -- --deny clippy::all -D warnings
+
+      - name: Verify that docs compile
+        run: RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+
+      - name: Check with all features enabled
+        run: cargo clippy --all-features -- --deny clippy::all -D warnings
+
+      - name: Run tests
+        run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,16 +23,16 @@ cuicui_chirp = ["cuicui_dsl", "dep:cuicui_chirp"]
 [dependencies]
 bevy = { version = "0.11", default-features = false, features = ["bevy_asset"] }
 bevy_mod_picking = { version = "0.15.0", optional = true, default-features = false }
-cuicui_chirp = { version = "0.10.0", optional = true }
+cuicui_chirp = { version = "0.10.0", optional = true, default-features = false, features = ["macros"] }
 cuicui_dsl = { version = "0.10.0", optional = true }
 non-empty-vec = { version = "0.2.2", default-features = false }
 
 [dev-dependencies]
 fastrand = "1.7"
-cuicui_layout_bevy_ui = "0.10.0"
-cuicui_layout = "0.10.0"
-bevy = { version = "0.11", default-features = true }
+cuicui_layout_bevy_ui = { version = "0.10.0", default-features = false }
+cuicui_layout = { version = "0.10.0", default-features = false }
+bevy = { version = "0.11", default-features = false, features = ["bevy_asset", "png", "x11", "default_font"] }
 
 [[example]]
 name = "ultimate_menu_navigation"
-required-features = ["cuicui_chirp"]
+required-features = ["cuicui_chirp", "bevy/filesystem_watcher", "cuicui_layout_bevy_ui/chirp", "cuicui_layout/reflect"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
 check:
 	cargo clippy --examples
+
 run:
 	cargo run --example ultimate_menu_navigation --features cuicui_dsl
+
+pre-hook:
+	cargo fmt --all -- --check
+	cargo clippy --no-default-features -- --deny clippy::all -D warnings
+	RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features
+	cargo clippy --all-features -- --deny clippy::all -D warnings
+	cargo test --all-features
+	cargo clippy --all-features --features="cuicui_chirp bevy/filesystem_watcher cuicui_layout_bevy_ui/chirp cuicui_layout/reflect" --example ultimate_menu_navigation

--- a/Readme.md
+++ b/Readme.md
@@ -374,7 +374,7 @@ To use the return key, change the `key_action` attribute.
 
 Otherwise, if you are not using default input handling, add this system:
 
-```rust
+```rust, no_run
 use bevy::prelude::*;
 use bevy_ui_navigation::prelude::{NavRequest, NavRequestSystem};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,8 @@
 [`NavRequest::ScopeMove`]: events::NavRequest::ScopeMove
 [`NavRequestSystem`]: NavRequestSystem
 */
-#![forbid(missing_docs)]
 #![doc = include_str!("../Readme.md")]
+#![forbid(missing_docs)]
 #![allow(clippy::unnecessary_lazy_evaluations)]
 
 mod commands;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,7 +1,7 @@
 //! System for the navigation tree and default input systems to get started.
 use crate::{
     events::{Direction, NavRequest, ScopeDirection},
-    resolve::{Focusable, Focused},
+    resolve::Focused,
 };
 
 #[cfg(feature = "bevy_ui")]
@@ -72,7 +72,7 @@ pub struct InputMapping {
     pub key_previous: KeyCode,
     /// Keyboard key for [`NavRequest::Unlock`]
     pub key_free: KeyCode,
-    /// Whether mouse hover gives focus to [`Focusable`] elements.
+    /// Whether mouse hover gives focus to [`Focusable`](crate::resolve::Focusable) elements.
     pub focus_follows_mouse: bool,
 }
 impl Default for InputMapping {
@@ -124,7 +124,7 @@ macro_rules! mapping {
 /// The button mapping may be controlled through the [`InputMapping`] resource.
 /// You may however need to customize the behavior of this system (typically
 /// when integrating in the game) in this case, you should write your own
-/// system that sends [`NavRequest`](crate::events::NavRequest) events
+/// system that sends [`NavRequest`] events
 pub fn default_gamepad_input(
     mut nav_cmds: EventWriter<NavRequest>,
     has_focused: Query<(), With<Focused>>,
@@ -195,7 +195,7 @@ pub fn default_gamepad_input(
 /// The button mapping may be controlled through the [`InputMapping`] resource.
 /// You may however need to customize the behavior of this system (typically
 /// when integrating in the game) in this case, you should write your own
-/// system that sends [`NavRequest`](crate::events::NavRequest) events.
+/// system that sends [`NavRequest`] events.
 pub fn default_keyboard_input(
     has_focused: Query<(), With<Focused>>,
     keyboard: Res<Input<KeyCode>>,
@@ -277,7 +277,7 @@ pub fn update_boundaries(
 
 #[cfg(feature = "pointer_focus")]
 fn send_request<E: EntityEvent>(
-    f: impl Fn(Query<&Focusable>, Res<ListenerInput<E>>, EventWriter<NavRequest>)
+    f: impl Fn(Query<&crate::resolve::Focusable>, Res<ListenerInput<E>>, EventWriter<NavRequest>)
         + Send
         + Sync
         + Copy
@@ -310,7 +310,7 @@ fn send_request<E: EntityEvent>(
 #[allow(clippy::type_complexity)]
 pub fn enable_click_request(
     input_mapping: Res<InputMapping>,
-    to_add: Query<Entity, (With<Focusable>, Without<On<Pointer<Click>>>)>,
+    to_add: Query<Entity, (With<crate::resolve::Focusable>, Without<On<Pointer<Click>>>)>,
     mut commands: Commands,
 ) {
     use crate::prelude::FocusState::Blocked;


### PR DESCRIPTION
Re-use the CI file from `cuicui_layout`, adapted to work with `bevy-ui-navigation`.

Closes #37